### PR TITLE
Changed syntax-highlighted text color to white for better readability.

### DIFF
--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -54,6 +54,11 @@ code,pre {
     font-size: small;
 }
 
+/* The snippet below changes syntax-highlighted text to white (#fff) instead of #353535 for better readability, as the original color blends too much with the background. */
+.highlight [class^="language-"] {
+	color: #fff;
+}
+
 code {
 	padding: .1rem;
 	border: none;


### PR DESCRIPTION
Hi, ronv.

I really like your "lines" theme, it is clean and visually appealing.

I just noticed that the syntax-highlighted text is difficult to read, as shown in the screenshot below:
![bilde](https://github.com/user-attachments/assets/fa857ed3-12d0-4d8d-a61c-34bc51eda09b)

I made a small tweak to fix it:
```css
.highlight [class^="language-"] {
	color: #fff;
}
```

With the CSS above applied, the new text now looks like this:
![bilde](https://github.com/user-attachments/assets/e0202c71-ba3c-4c72-8927-425337c632d1)

I wanted to share this change in case it helps with the theme’s readability. Let me know what you think!
